### PR TITLE
deps(all): update ag-toolkit to 0.1.4

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git"

--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "agbd",
       "dependencies": {
-        "ag-toolkit": "0.1.3",
+        "ag-toolkit": "0.1.4",
         "ink": "6.3.1",
         "ink-select-input": "6.2.0",
         "ink-spinner": "5.0.0",
@@ -77,7 +77,7 @@
 
     "acorn-walk": ["acorn-walk@8.3.4", "", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g=="],
 
-    "ag-toolkit": ["ag-toolkit@0.1.3", "", { "dependencies": { "ink": "6.3.1", "ink-select-input": "6.2.0", "ink-spinner": "5.0.0", "react": "19.1.1", "simple-git": "3.28.0", "valibot": "1.1.0" } }, "sha512-k5me8/xVdTsqrvzifnI8hjiC4kikV1GJthUQa3g1mMhZCb7eSNztnoxzORRcpIhQagM8hCkRX81UfTcyFI+0+w=="],
+    "ag-toolkit": ["ag-toolkit@0.1.4", "", { "dependencies": { "ink": "6.3.1", "ink-select-input": "6.2.0", "ink-spinner": "5.0.0", "react": "19.2.0", "simple-git": "3.28.0", "valibot": "1.1.0" } }, "sha512-7zZyvCPvimiDArm3WYQxy0KxB+qqWhuNQcjgTwpc+EOcA0/4ZlWOscaZZMHC+dDlpNPgwjZNTEVADnfRnAjbkQ=="],
 
     "ansi-escapes": ["ansi-escapes@7.1.1", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "agbd",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"description": "Interactive CLI to safely inspect and delete Git branches (local and remote)",
 	"license": "MIT",
 	"bin": "dist/cli.js",
@@ -36,7 +36,7 @@
 		"access": "public"
 	},
 	"dependencies": {
-		"ag-toolkit": "0.1.3",
+		"ag-toolkit": "0.1.4",
 		"ink": "6.3.1",
 		"ink-select-input": "6.2.0",
 		"ink-spinner": "5.0.0",


### PR DESCRIPTION
## Summary

Update ag-toolkit from 0.1.3 to 0.1.4 to resolve React hooks error that occurred when running `--config set` command.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Updated ag-toolkit dependency from 0.1.3 to 0.1.4
- Updated bun.lock to reflect the new dependency version
- Updated biome.json schema version to 2.2.5

## Testing

- [x] I have tested this manually
- Verified that `bun run ./dist/cli.js --config set` no longer throws React hooks error
- The error "Invalid hook call. Hooks can only be called inside of the body of a function component" has been resolved

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Context

This fixes the React version conflict between the main project (React 19.2.0) and ag-toolkit's previous version (React 19.1.1). The new version 0.1.4 of ag-toolkit uses React 19.2.0, eliminating the multiple React instance issue.